### PR TITLE
Feature to SNAT VPC CIDRs with node IP

### DIFF
--- a/pkg/networkutils/mocks/network_mocks.go
+++ b/pkg/networkutils/mocks/network_mocks.go
@@ -64,6 +64,19 @@ func (mr *MockNetworkAPIsMockRecorder) GetExcludeSNATCIDRs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExcludeSNATCIDRs", reflect.TypeOf((*MockNetworkAPIs)(nil).GetExcludeSNATCIDRs))
 }
 
+// GetIncludeSNATCIDRs mocks base method.
+func (m *MockNetworkAPIs) GetIncludeVPCCIDRsToSNAT() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIncludeVPCCIDRsToSNAT")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+func (mr *MockNetworkAPIsMockRecorder) GetIncludeVPCCIDRsToSNAT() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIncludeVPCCIDRsToSNAT", reflect.TypeOf((*MockNetworkAPIs)(nil).GetIncludeVPCCIDRsToSNAT()))
+}
+
 // GetExternalServiceCIDRs mocks base method.
 func (m *MockNetworkAPIs) GetExternalServiceCIDRs() []string {
 	m.ctrl.T.Helper()

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -813,15 +813,15 @@ func isRuleExistsError(err error) bool {
 // GetConfigForDebug returns the active values of the configuration env vars (for debugging purposes).
 func GetConfigForDebug() map[string]interface{} {
 	return map[string]interface{}{
-		envConnmark:             getConnmark(),
-		envExcludeSNATCIDRs:     parseCIDRString(envExcludeSNATCIDRs),
-		envIncludeSNATCIDRs:     parseCIDRString(envIncludeSNATCIDRs),
-		envExternalSNAT:         useExternalSNAT(),
-		envExternalServiceCIDRs: parseCIDRString(envExternalServiceCIDRs),
-		envMTU:                  GetEthernetMTU(""),
-		envVethPrefix:           getVethPrefixName(),
-		envNodePortSupport:      nodePortSupportEnabled(),
-		envRandomizeSNAT:        typeOfSNAT(),
+		envConnmark:              getConnmark(),
+		envExcludeSNATCIDRs:      parseCIDRString(envExcludeSNATCIDRs),
+		envIncludeVPCCIDRsToSNAT: parseCIDRString(envIncludeVPCCIDRsToSNAT),
+		envExternalSNAT:          useExternalSNAT(),
+		envExternalServiceCIDRs:  parseCIDRString(envExternalServiceCIDRs),
+		envMTU:                   GetEthernetMTU(""),
+		envVethPrefix:            getVethPrefixName(),
+		envNodePortSupport:       nodePortSupportEnabled(),
+		envRandomizeSNAT:         typeOfSNAT(),
 	}
 }
 

--- a/pkg/networkutils/network.go
+++ b/pkg/networkutils/network.go
@@ -30,6 +30,7 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 
 	"github.com/aws/amazon-vpc-cni-k8s/pkg/sgpp"
+	"github.com/aws/amazon-vpc-cni-k8s/utils"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -86,6 +87,12 @@ const (
 	// will be written to the iptables for each item. If an item is not an ipv4 range it will be skipped.
 	// Defaults to empty.
 	envExcludeSNATCIDRs = "AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS"
+
+	// This environment is used to specify a comma-separated list of IPv4 CIDRs to include in SNAT. No iptables rules will
+	// be written for each item. If an item is not an ipv4 range it will be skipped.
+	// Defaults to empty
+
+	envIncludeVPCCIDRsToSNAT = "AWS_VPC_K8S_CNI_INCLUDE_VPC_CIDRS_TO_SNAT"
 
 	// This environment is used to specify a comma-separated list of IPv4 CIDRs that require routing lookup in
 	// main routing table. An IP rule is created for each CIDR.
@@ -155,6 +162,7 @@ type NetworkAPIs interface {
 	UpdateHostIptablesRules(vpcCIDRs []string, primaryMAC string, primaryAddr *net.IP, v4Enabled bool, v6Enabled bool) error
 	UseExternalSNAT() bool
 	GetExcludeSNATCIDRs() []string
+	GetIncludeVPCCIDRsToSNAT() []string
 	GetExternalServiceCIDRs() []string
 	GetRuleList() ([]netlink.Rule, error)
 	GetRuleListBySrc(ruleList []netlink.Rule, src net.IPNet) ([]netlink.Rule, error)
@@ -167,6 +175,7 @@ type linuxNetwork struct {
 	useExternalSNAT        bool
 	ipv6EgressEnabled      bool
 	excludeSNATCIDRs       []string
+	includeVPCCIDRsToSNAT  []string
 	externalServiceCIDRs   []string
 	typeOfSNAT             snatType
 	nodePortSupportEnabled bool
@@ -194,6 +203,7 @@ func New() NetworkAPIs {
 		useExternalSNAT:        useExternalSNAT(),
 		ipv6EgressEnabled:      ipV6EgressEnabled(),
 		excludeSNATCIDRs:       parseCIDRString(envExcludeSNATCIDRs),
+		includeVPCCIDRsToSNAT:  parseCIDRString(envIncludeVPCCIDRsToSNAT),
 		externalServiceCIDRs:   parseCIDRString(envExternalServiceCIDRs),
 		typeOfSNAT:             typeOfSNAT(),
 		nodePortSupportEnabled: nodePortSupportEnabled(),
@@ -418,9 +428,13 @@ func (n *linuxNetwork) buildIptablesSNATRules(vpcCIDRs []string, primaryAddr *ne
 		isExclusion bool
 	}
 	var allCIDRs []snatCIDR
+	includeCIDRsToSNAT := sets.NewString(n.includeVPCCIDRsToSNAT...)
+
 	for _, cidr := range vpcCIDRs {
-		log.Debugf("Adding %s CIDR to NAT chain", cidr)
-		allCIDRs = append(allCIDRs, snatCIDR{cidr: cidr, isExclusion: false})
+		if !includeCIDRsToSNAT.Has(cidr) {
+			log.Debugf("Adding %s CIDR to NAT chain", cidr)
+			allCIDRs = append(allCIDRs, snatCIDR{cidr: cidr, isExclusion: false})
+		}
 	}
 	for _, cidr := range n.excludeSNATCIDRs {
 		log.Debugf("Adding %s Excluded CIDR to NAT chain", cidr)
@@ -550,6 +564,8 @@ func (n *linuxNetwork) buildIptablesConnmarkRules(vpcCIDRs []string, ipt iptable
 	allCIDRs = append(allCIDRs, vpcCIDRs...)
 	allCIDRs = append(allCIDRs, n.excludeSNATCIDRs...)
 	excludeCIDRs := sets.NewString(n.excludeSNATCIDRs...)
+
+	allCIDRs = utils.DifferenceBetweensStringSlices(allCIDRs, n.includeVPCCIDRsToSNAT)
 
 	log.Debugf("Total CIDRs to exempt from connmark rules - %d", len(allCIDRs))
 	var chains []string
@@ -799,6 +815,7 @@ func GetConfigForDebug() map[string]interface{} {
 	return map[string]interface{}{
 		envConnmark:             getConnmark(),
 		envExcludeSNATCIDRs:     parseCIDRString(envExcludeSNATCIDRs),
+		envIncludeSNATCIDRs:     parseCIDRString(envIncludeSNATCIDRs),
 		envExternalSNAT:         useExternalSNAT(),
 		envExternalServiceCIDRs: parseCIDRString(envExternalServiceCIDRs),
 		envMTU:                  GetEthernetMTU(""),
@@ -834,6 +851,15 @@ func (n *linuxNetwork) GetExcludeSNATCIDRs() []string {
 		return nil
 	}
 	return parseCIDRString(envExcludeSNATCIDRs)
+}
+
+// GetIncludeSNATCIDRs returns a list of CIDRs that should be included in SNAT if UseExternalSNAT is false,
+// otherwise it returns an empty list.
+func (n *linuxNetwork) GetIncludeVPCCIDRsToSNAT() []string {
+	if useExternalSNAT() {
+		return nil
+	}
+	return parseCIDRString(envIncludeVPCCIDRsToSNAT)
 }
 
 // GetExternalServiceCIDRs return a list of CIDRs that should always be routed to via main routing table.

--- a/pkg/networkutils/network_test.go
+++ b/pkg/networkutils/network_test.go
@@ -403,6 +403,55 @@ func TestSetupHostNetworkWithExcludeSNATCIDRs(t *testing.T) {
 		}, mockIptables.(*mock_iptables.MockIptables).DataplaneState)
 }
 
+func TestSetupHostNetworkWithIncludeSNATCIDRs(t *testing.T) {
+	ctrl, mockNetLink, _, mockNS, mockIptables := setup(t)
+	defer ctrl.Finish()
+
+	ln := &linuxNetwork{
+		useExternalSNAT:        false,
+		ipv6EgressEnabled:      false,
+		includeVPCCIDRsToSNAT:  []string{"10.12.0.0/16", "10.13.0.0/16"},
+		nodePortSupportEnabled: true,
+		mainENIMark:            defaultConnmark,
+		mtu:                    testMTU,
+		vethPrefix:             eniPrefix,
+
+		netLink: mockNetLink,
+		ns:      mockNS,
+		newIptables: func(iptables.Protocol) (iptableswrapper.IPTablesIface, error) {
+			return mockIptables, nil
+		},
+	}
+	setupNetLinkMocks(ctrl, mockNetLink)
+
+	vpcCIDRs := []string{"10.10.0.0/16", "10.11.0.0/16", "10.12.0.0/16", "10.13.0.0/16"}
+	err := ln.SetupHostNetwork(vpcCIDRs, loopback, &testENINetIP, false, true, false)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		map[string]map[string][][]string{
+			"nat": {
+				"AWS-SNAT-CHAIN-0":     [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-1"}},
+				"AWS-SNAT-CHAIN-1":     [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-2"}},
+				"AWS-SNAT-CHAIN-2":     [][]string{{"!", "-o", "vlan+", "-m", "comment", "--comment", "AWS, SNAT", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "SNAT", "--to-source", "10.10.10.20"}},
+				"POSTROUTING":          [][]string{{"-m", "comment", "--comment", "AWS SNAT CHAIN", "-j", "AWS-SNAT-CHAIN-0"}},
+				"AWS-CONNMARK-CHAIN-0": [][]string{{"!", "-d", "10.10.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, VPC CIDR", "-j", "AWS-CONNMARK-CHAIN-1"}},
+				"AWS-CONNMARK-CHAIN-1": [][]string{{"!", "-d", "10.11.0.0/16", "-m", "comment", "--comment", "AWS CONNMARK CHAIN, VPC CIDR", "-j", "AWS-CONNMARK-CHAIN-2"}},
+				"AWS-CONNMARK-CHAIN-2": [][]string{{"-m", "comment", "--comment", "AWS, CONNMARK", "-j", "CONNMARK", "--set-xmark", "0x80/0x80"}},
+				"PREROUTING": [][]string{
+					{"-i", "eni+", "-m", "comment", "--comment", "AWS, outbound connections", "-j", "AWS-CONNMARK-CHAIN-0"},
+					{"-m", "comment", "--comment", "AWS, CONNMARK", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+				},
+			},
+			"mangle": {
+				"PREROUTING": [][]string{
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "lo", "-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in", "-j", "CONNMARK", "--set-mark", "0x80/0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "eni+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+					{"-m", "comment", "--comment", "AWS, primary ENI", "-i", "vlan+", "-j", "CONNMARK", "--restore-mark", "--mask", "0x80"},
+				},
+			},
+		}, mockIptables.(*mock_iptables.MockIptables).DataplaneState)
+}
+
 func TestSetupHostNetworkCleansUpStaleSNATRules(t *testing.T) {
 	ctrl, mockNetLink, _, mockNS, mockIptables := setup(t)
 	defer ctrl.Finish()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -42,3 +42,18 @@ func GetEnv(env, defaultVal string) string {
 	}
 	return defaultVal
 }
+
+// Returns de difference between two string slices
+func DifferenceBetweensStringSlices(a, b []string) []string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[x] = struct{}{}
+	}
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
When using custom network with eniconfigs to have specific VPC CIDRs for pods, the traffic from the pods targeting anything inside the CIDRs of the VPC does NOT get SNATed, even the traffic that goes outside the cluster to instances allocated inside the VPC.

This can be a problem if multiple EKS clusters are in the same VPC, because if these clusters have ingresses that need to just whitelist traffic coming from the VPC the new pods CIDRs need to be whitelisted too, this is a problem when there are thousands of ingresses that are owned by different teams in different clusters since it means changing an interface for this teams that traffic would not only come with IPs from the nodes CIDR.

If all traffic that is not pod-to-pod communication would be SNATed, mimicking the behaviour of having an overlay network for pods, the pods IPs could be abstracted and so not have the problem mentioned.

**What does this PR do / Why do we need it**:
It allows you to select which CIDRs from the VPC will be SNATed when trying to contact them.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:

**Testing done on this change**:
No
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
No
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, No

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->
No
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
